### PR TITLE
.github: add github action to automate PR handling

### DIFF
--- a/.github/workflows/repo-lockdown.yml
+++ b/.github/workflows/repo-lockdown.yml
@@ -1,0 +1,25 @@
+name: 'Repo Lockdown'
+
+on:
+  pull_request_target:
+    types: opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  action:
+    if: github.repository == 'Dunky-Z/buildroot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v4
+        with:
+          pr-comment: |
+            Please do not submit a Pull Request via GitHub. Buildroot makes use of a
+            [mailing list](http://lists.buildroot.org/mailman/listinfo/buildroot) for patch submission and review.
+            See [submitting your own patches](http://buildroot.org/manual.html#submitting-patches) for more info.
+
+            Thanks for your help!
+          lock-pr: true
+          close-pr: true
+


### PR DESCRIPTION
This patch updates the Buildroot repository's GitHub configuration to better manage incoming pull requests.

- Added a new GitHub Actions workflow (`repo-lockdown.yml`) to automatically handle new pull requests.

The new workflow:
- Triggers on new pull requests.
- Uses the `dessant/repo-lockdown` action to:
  - Comment on the pull request, guiding contributors to use the mailing list for patch submission.
  - Lock the pull request to prevent further discussion.
  - Close the pull request.

This change ensures that contributors are properly directed to the preferred method of patch submission via the mailing list, maintaining consistency and streamlining the review process.

Please do not submit a Pull Request via GitHub. Buildroot makes use of a
[mailing list](http://lists.buildroot.org/mailman/listinfo/buildroot) for patch submission and review.
See [submitting your own patches](http://buildroot.org/manual.html#submitting-patches) for more info.

Thanks for your help!

